### PR TITLE
Remove Loom embed from homepage

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -451,10 +451,6 @@ function saveRef(){
   </div>
   <div class="wrapper">
     <div class="page-container">
-      <section id="demo" class="section hide">
-        <h2 id="features" class="heading-2">Demo</h2>
-        <div style="padding-top:75%" class="video w-video w-embed"><iframe class="embedly-embed" src="https://cdn.embedly.com/widgets/media.html?src=https%3A%2F%2Fwww.loom.com%2Fembed%2Ff4de67803e0942248a5e640245f64ffc&display_name=Loom&url=https%3A%2F%2Fwww.loom.com%2Fshare%2Ff4de67803e0942248a5e640245f64ffc&image=https%3A%2F%2Fcdn.loom.com%2Fsessions%2Fthumbnails%2Ff4de67803e0942248a5e640245f64ffc-00001.gif&key=96f1f04c5f4143bcb0f2e68c87d65feb&type=text%2Fhtml&schema=loom" width="940" height="705" scrolling="no" allowfullscreen="" title="Decentralized Authentication with Security Keys"></iframe></div>
-      </section>
       <section id="screenshots" class="section">
         <h2 id="features" class="heading-2">Screenshots</h2>
         <div class="w-layout-grid grid">


### PR DESCRIPTION
## Summary
The embedded Loom video on the homepage was loading inside an Embedly iframe and pulling in:
- Sentry error tracking (`o398470.ingest.sentry.io`)
- Atlassian analytics stack (`xp.atlassian.com`, `as.atlassian.com`, `api-private.atlassian.com`, `api.atlassian.com`)
- Segment Analytics.js anonymous ID (`ajs_anonymous_id`, 5-year cookie)
- Loom GraphQL + insights + feature flags (12+ analytics POSTs in the first 10s)
- ~6MB of third-party JS / 80+ chunks

The demo section was already hidden via `class="section hide"`, so users never saw it — but the iframe still loaded on every page view and fired all the trackers above.

## Changes
- Deleted the entire `<section id="demo">` from `website/index.html` (4 lines)
- No CSS or anchor links pointed to `#demo`, so nothing else needed to change

## Test plan
- [ ] Open the deployed preview, confirm the homepage renders normally (Screenshots section follows the previous section directly)
- [ ] DevTools → Network tab: no requests to `loom.com`, `embedly.com`, `sentry.io`, or `atlassian.com`
- [ ] DevTools → Application → Cookies: no `ajs_anonymous_id`, `loom_anon_comment`, `loom_referral_video`