### PR TITLE
Update homepage subheadline

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -89,7 +89,7 @@ function saveRef(){
           <div class="div-block-148">
             <div class="div-block-151">
               <h1 class="heading">Protect Your <span class="text-span-2">Secrets</span>. Forever.</h1>
-              <p class="subheading">A private vault for passwords, keys, and important notes, built to last. <br>No subscriptions. No lockouts.<br></p>
+              <p class="subheading">Private vault for passwords, keys, and notes that's built to outlive any company. <br>Pay once. Own it for life.<br></p>
             </div>
           </div>
           <div class="div-block-149">


### PR DESCRIPTION
## Summary
Refreshes the hero subheadline to better earn the headline's "Forever." claim.

**Before:**
> A private vault for passwords, keys, and important notes, built to last.
> No subscriptions. No lockouts.

**After:**
> Private vault for passwords, keys, and notes that's built to outlive any company.
> Pay once. Own it for life.

Why: "built to last" was the weakest beat (vague, slight cliche) and "No subscriptions. No lockouts." didn't explain *why* lockouts can't happen. The new copy earns "Forever" by naming the actual differentiator (outliving the company) and replacing the negative-framed bullets with a positive promise ("Own it for life"). Single line change in `website/index.html`.

## Test plan
- [ ] Eyeball the hero on the deployed preview — copy reads cleanly under "Protect Your Secrets. Forever."
- [ ] Line break between sentences still renders (the `<br>` is preserved)