### PR TITLE
Shorten subheadline; remove misleading 'Pay once' claim

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -89,7 +89,7 @@ function saveRef(){
           <div class="div-block-148">
             <div class="div-block-151">
               <h1 class="heading">Protect Your <span class="text-span-2">Secrets</span>. Forever.</h1>
-              <p class="subheading">Private vault for passwords, keys, and notes. <br>Built to outlive any company. Pay once. Own it for life.<br></p>
+              <p class="subheading">Private vault for passwords, keys, and notes — built to outlive any company.</p>
             </div>
           </div>
           <div class="div-block-149">


### PR DESCRIPTION
## Summary
The current hero subheadline says 'Pay once. Own it for life.' — but BitNote is per-transaction, not a one-time purchase. That framing actively misleads visitors about the pricing model.

**Before:**
> Private vault for passwords, keys, and notes.
> Built to outlive any company. Pay once. Own it for life.

**After:**
> Private vault for passwords, keys, and notes — built to outlive any company.

## Why
1. **Accuracy**: 'Pay once' implies one-time-purchase. BitNote charges per blockchain transaction (small fees per note save). Removing the claim avoids setting wrong expectations that would surface as support / churn issues later.
2. **Mobile rendering**: Dropping the `<br>` and consolidating to one em-dashed sentence wraps cleanly into 3 lines on a 375px viewport. The previous version had two visual orphans ('and notes.' and 'Pay'). Tested via headless browser at mobile viewport.
3. **Focus**: Hero now does two jobs (definition + durability claim that earns 'Forever') instead of four (also pricing + ownership). Pricing details belong in the buy flow / further down the page where the per-transaction model can be explained accurately.

## Test plan
- [ ] Eyeball desktop and mobile (375px) renders on the deployed preview
- [ ] Confirm em-dash character (—, U+2014) renders correctly across browsers
- [ ] Verify no other places on the page or in app.bitnote.xyz docs claim 'pay once' framing (followup if any)