### PR TITLE
Fix share card: sync description meta tags + self-host OG image

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="utf-8">
   <title>BitNote</title>
-  <meta content="A private vault for passwords, keys, and important notes, built to stay yours. No subscriptions. No lockouts." name="description">
+  <meta content="Private vault for passwords, keys, and notes — built to outlive any company." name="description">
   <meta content="BitNote" property="og:title">
-  <meta content="A private vault for passwords, keys, and important notes, built to stay yours. No subscriptions. No lockouts." property="og:description">
-  <meta content="https://uploads-ssl.webflow.com/63d429b4398bbf8a2ca4e666/660ebd857735e99c477ecf93_BitNote%20Frame%202159%20(2).png" property="og:image">
+  <meta content="Private vault for passwords, keys, and notes — built to outlive any company." property="og:description">
+  <meta content="https://www.bitnote.xyz/images/BitNote-Frame-2159-2.png" property="og:image">
   <meta content="BitNote" property="twitter:title">
-  <meta content="A private vault for passwords, keys, and important notes, built to stay yours. No subscriptions. No lockouts." property="twitter:description">
-  <meta content="https://uploads-ssl.webflow.com/63d429b4398bbf8a2ca4e666/660ebd857735e99c477ecf93_BitNote%20Frame%202159%20(2).png" property="twitter:image">
+  <meta content="Private vault for passwords, keys, and notes — built to outlive any company." property="twitter:description">
+  <meta content="https://www.bitnote.xyz/images/BitNote-Frame-2159-2.png" property="twitter:image">
   <meta property="og:type" content="website">
   <meta content="summary_large_image" name="twitter:card">
   <meta content="width=device-width, initial-scale=1" name="viewport">


### PR DESCRIPTION
## Summary
The share card preview shown when bitnote.xyz is pasted into iMessage / Slack / Discord / Twitter / LinkedIn was serving:
- An out-of-date description (older than even the 'Pay once' version we just fixed)
- An OG image hosted on Webflow's CDN (`uploads-ssl.webflow.com`), not on our own infrastructure

## Changes
- Three description meta tags (line 6/8/11) now match the current visible subheading: `Private vault for passwords, keys, and notes — built to outlive any company.`
- `og:image` and `twitter:image` now point at `https://www.bitnote.xyz/images/BitNote-Frame-2159-2.png` (already in the repo, byte-for-byte identical to the Webflow-hosted copy — zero visual change, just self-hosted)

## Not addressed in this PR
- The OG image *content* itself — it's an app screenshot showing 'Super Secret Private Key' demo content. May want a redesigned, marketing-tuned OG image at some point (1200×630, polished, brand-forward). That's a design task, not a code fix.
- Cache busting — iMessage / Slack / etc cache OG previews aggressively. After this lands, links shared in the past few days will keep showing the old preview until each platform's cache expires. Force-refresh via Twitter Card Validator, Facebook Sharing Debugger, LinkedIn Post Inspector once deployed.

## Test plan
- [ ] After deploy, paste `https://www.bitnote.xyz` into a Slack DM or Twitter draft and confirm the new description shows
- [ ] Run https://cards-dev.twitter.com/validator on the URL to force-refresh Twitter's cache
- [ ] Run https://www.linkedin.com/post-inspector/ to force-refresh LinkedIn's cache
- [ ] Verify `https://www.bitnote.xyz/images/BitNote-Frame-2159-2.png` returns 200 (it should — file is in `website/images/`)